### PR TITLE
New setup.py installs the module and scripts.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+from glob import glob
+from setuptools import setup, find_packages
+
+if __name__ == "__main__":
+    setup(name='dust',
+          version='dev',
+          description='Hanner-Harker thermal emission model and spectral fitting',
+          author="David E. Harker, Michael S. P. Kelley",
+          url="https://github.com/dharker-ucsd/thermal-dust-model/",
+          packages=find_packages(),
+          scripts=glob('scripts/*.py'),
+          requires=['numpy', 'scipy', 'astropy', 'matplotlib'],
+    )


### PR DESCRIPTION
Install with: `python3 setup.py install` or `python3 setup.py install --prefix=/home/msk/local` as usual.  If the install location is in your path, then the scripts can be run from anywhere.