### PR TITLE
Prevent floating underflow (or similar) by isolating delta scale factor.

### DIFF
--- a/scripts/fit-idl-save.py
+++ b/scripts/fit-idl-save.py
@@ -261,7 +261,6 @@ if args.n > 0:
 
     # Incorporate delta scaling factor
     mcall.scales *= delta**2
-    
     for pfx in ['', '+', '-']:
         for s in scale_names + ['Mtot']:
             mcbest[pfx + s] *= delta**2


### PR DESCRIPTION
Try this out.  I keep the delta scale factor out until writing to a file.  Please verify some previous fits, especially total mass values.
