### PR TITLE
Handling single material fits.

### DIFF
--- a/dust/results.py
+++ b/dust/results.py
@@ -157,7 +157,7 @@ class ModelResults:
                 try:
                     tab[name] = numerator / denominator
                 except ZeroDivisionError:
-                    tab[name] = 0.
+                    tab[name] = -1
 
                 numerator_names = [x.value for x in equation[0]]
                 denominator_names = [x.value for x in equation[1]]


### PR DESCRIPTION
The fitting routine could not handle fitting a single material since when it calculated ratios, it encountered a divide by zero error.  Specifically, in `results.py`, the code failed when it got to: 
`tab[name] = numerator / denominator`.  No model output was produced.

I inserted the code:
```
try:
    tab[name] = numerator / denominator
except ZeroDivisionError:
    tab[name] = 0.
```
I do not know if setting `tab[name] = 0.` is the best at this point.  When modeling just using material AC, there are no errors and S/C and f_cryst = 0.  When modeling using material like AP, warnings are thrown but the modeling completes with S/C = inf and f_cryst = 0.  Most likely the warnings come from computing the "error" on S/C which ends up as nan.  Here is an example of the warning:
```
/Users/harker/python/thermal-dust-model/dust/results.py:158: RuntimeWarning: divide by zero encountered in double_scalars
  tab[name] = numerator / denominator
/Users/harker/python/thermal-dust-model/dust/results.py:158: RuntimeWarning: divide by zero encountered in true_divide
  tab[name] = numerator / denominator
/Users/harker/python/thermal-dust-model/dust/fit.py:358: RuntimeWarning: invalid value encountered in double_scalars
  summary['+' + col] = [ul - c]
/Users/harker/python/thermal-dust-model/dust/fit.py:359: RuntimeWarning: invalid value encountered in double_scalars
  summary['-' + col] = [c - ll]
/Users/harker/python/thermal-dust-model/dust/fit.py:365: RuntimeWarning: invalid value encountered in double_scalars
  col, c, ul - c, ll - c))
```